### PR TITLE
Write model

### DIFF
--- a/source/pygyre/__init__.py
+++ b/source/pygyre/__init__.py
@@ -580,35 +580,34 @@ def write_model(filename, model_table):
     # check for invalid input
     meta_keys = ['n', 'M_star', 'R_star', 'L_star', 'version']
     col_keys = ['k',
-                        'r',
-                        'M_r',
-                        'L_r',
-                        'P',
-                        'T',
-                        'rho',
-                        'nabla',
-                        'N^2',
-                        'Gamma_1',
-                        'nabla_ad',
-                        'delta',
-                        'kap',
-                        'kap kap_T',
-                        'kap kap_rho',
-                        'eps_nuc',
-                        'eps_nuc*eps_T',
-                        'eps_nuc*eps_rho',
-                        'eps_grav',
-                        'Omega_rot']
+                'r',
+                'M_r',
+                'L_r',
+                'P',
+                'T',
+                'rho',
+                'nabla',
+                'N^2',
+                'Gamma_1',
+                'nabla_ad',
+                'delta',
+                'kap',
+                'kap kap_T',
+                'kap kap_rho',
+                'eps_nuc',
+                'eps_nuc*eps_T',
+                'eps_nuc*eps_rho',
+                'eps_grav',
+                'Omega_rot']
     
-    if list(model_table.meta.keys()) != meta_keys or \
-    list(model_table.colnames) != col_keys:
+    if ( list(model_table.meta.keys()) != meta_keys or
+         list(model_table.colnames) != col_keys ):
         raise ValueError("Invalid table input: meta data or column data is either missing or mislabeled")
     elif model_table.meta['n'] != len(model_table):
-        raise ValueError(("Invalid table input: Expected {:d} columns from meta data, " \
+        raise ValueError(("Invalid table input: Expected {:d} columns from meta data, "
                          "table actually has {:d} columns").format(model_table.meta['n'], len(model_table)))
     
     # open the file to write in
-    # I bet this could be done more elagantly, but this works for now
     with open(filename, 'w') as f:
         # Write the meta data in the top line
         meta_data = '{:d} {:.16E} {:.16E} {:.16E} {:d}\n'.format(*model_table.meta.values())

--- a/source/pygyre/__init__.py
+++ b/source/pygyre/__init__.py
@@ -568,7 +568,8 @@ def write_model(filename, model_table):
     filename : str
         The name of the file to write to
     model_table : astropy.table.Table
-        model data as would be produced from `read_model()`
+        model data as would be produced from calling `read_model()`
+        on a MESA file
 
     Raises
     ------

--- a/source/pygyre/__init__.py
+++ b/source/pygyre/__init__.py
@@ -556,3 +556,68 @@ def _interpret(s):
         except ValueError:
 
             return s
+            
+def write_model(filename, model_table):
+    """ 
+
+    Creates a stellar model file in the MESA v1.20 format 
+    from an astropy table that can be read by GYRE as input
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file to write to
+    model_table : astropy.table.Table
+        model data as would be produced from `read_model()`
+
+    Raises
+    ------
+    ValueError
+        If `model_table` does not match expected format
+
+    """
+    # check for invalid input
+    meta_keys = ['n', 'M_star', 'R_star', 'L_star', 'version']
+    col_keys = ['k',
+                        'r',
+                        'M_r',
+                        'L_r',
+                        'P',
+                        'T',
+                        'rho',
+                        'nabla',
+                        'N^2',
+                        'Gamma_1',
+                        'nabla_ad',
+                        'delta',
+                        'kap',
+                        'kap kap_T',
+                        'kap kap_rho',
+                        'eps_nuc',
+                        'eps_nuc*eps_T',
+                        'eps_nuc*eps_rho',
+                        'eps_grav',
+                        'Omega_rot']
+    
+    if list(model_table.meta.keys()) != meta_keys or \
+    list(model_table.colnames) != col_keys:
+        raise ValueError("Invalid table input: meta data or column data is either missing or mislabeled")
+    elif model_table.meta['n'] != len(model_table):
+        raise ValueError(("Invalid table input: Expected {:d} columns from meta data, " \
+                         "table actually has {:d} columns").format(model_table.meta['n'], len(model_table)))
+    
+    # open the file to write in
+    # I bet this could be done more elagantly, but this works for now
+    with open(filename, 'w') as f:
+        # Write the meta data in the top line
+        meta_data = '{:d} {:.16E} {:.16E} {:.16E} {:d}\n'.format(*model_table.meta.values())
+        f.write(meta_data)
+
+        # Now write the point data
+        row_str_format = '{:d}'
+        for i in range(1, len(model_table[0])): row_str_format += ' {:.16E}'
+        row_str_format += '\n'
+        for row in range(len(model_table)):
+            row_data = row_str_format.format(*model_table[row].as_void())
+            f.write(row_data)
+            


### PR DESCRIPTION
Created a function to take an astropy table generated from `read_model()` to write a data file in the MESA v1.20 format for GYRE to use.

Note: the white space of the file generated will not be identical to what MESA outputs, but GYRE is still capable of parsing the file just fine